### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Swift在iOS 8发布的时候推向市场，用来取代现有的Objective-C语�
 *    [StackOverflow上的Swift讨论](http://stackoverflow.com/questions/tagged/swift-language)
 *    github上的swift内容 [search结果](https://github.com/search?l=Swift&q=swift&ref=cmdform&type=Repositories)
 *    [Swift Cheatsheet](http://cdn2.raywenderlich.com/wp-content/uploads/2014/06/RW-Swift-Cheatsheet-0_3.pdf)
-*    [Swift & Cocoapods](https://medium.com/swift-programming/swift-cocoapods-da09d8ba6dd2) How to integrate Cocoapods into a vanilla Swift project
+*    [Swift & CocoaPods](https://medium.com/swift-programming/swift-cocoapods-da09d8ba6dd2) How to integrate CocoaPods into a vanilla Swift project
 *    [Swift Toolbox](http://www.swifttoolbox.io)
 
 


### PR DESCRIPTION

This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
